### PR TITLE
Make HttpUtils have a per-instance cookiefactory

### DIFF
--- a/src/main/java/com/sumologic/client/SumoLogicClient.java
+++ b/src/main/java/com/sumologic/client/SumoLogicClient.java
@@ -12,6 +12,7 @@ import com.sumologic.client.collectors.model.*;
 import com.sumologic.client.model.SearchRequest;
 import com.sumologic.client.model.SearchResponse;
 import com.sumologic.client.search.SearchClient;
+import com.sumologic.client.util.HttpUtils;
 
 import java.net.URL;
 
@@ -25,6 +26,7 @@ import java.net.URL;
 public class SumoLogicClient implements SumoLogic {
 
     // Instance fields.
+    private HttpUtils httpUtils = new HttpUtils();
 
     private String protocol = "https";
     private String hostname = "api.sumologic.com";
@@ -32,9 +34,9 @@ public class SumoLogicClient implements SumoLogic {
     private Credentials credentials;
     private static JsonFactory jsonFactory = new JsonFactory();
 
-    private SearchClient searchClient = new SearchClient();
-    private CollectorsClient collectorsClient = new CollectorsClient();
-    private SearchJobClient searchJobClient = new SearchJobClient();
+    private SearchClient searchClient = new SearchClient(httpUtils);
+    private CollectorsClient collectorsClient = new CollectorsClient(httpUtils);
+    private SearchJobClient searchJobClient = new SearchJobClient(httpUtils);
 
     // Implementation.
 

--- a/src/main/java/com/sumologic/client/collectors/CollectorsClient.java
+++ b/src/main/java/com/sumologic/client/collectors/CollectorsClient.java
@@ -11,8 +11,15 @@ import com.sumologic.client.util.SumoEntityResponseHandler;
 
 public class CollectorsClient {
 
+    private HttpUtils httpUtils;
+
+    public CollectorsClient(HttpUtils httpUtils) {
+        this.httpUtils = httpUtils;
+    }
+
+
     public GetCollectorsResponse get(ConnectionConfig config, GetCollectorsRequest request) {
-        return HttpUtils.get(config, UrlParameters.COLLECTORS_SERVICE, request,
+        return httpUtils.get(config, UrlParameters.COLLECTORS_SERVICE, request,
                 HttpUtils.toRequestHeaders(),
                 new DeserializingResponseHandler<GetCollectorsRequest,
                         GetCollectorsResponse>(GetCollectorsResponse.class),
@@ -20,7 +27,7 @@ public class CollectorsClient {
     }
 
     public GetCollectorResponse get(ConnectionConfig config, GetCollectorRequest request) {
-        return HttpUtils.get(config, getCollectorEndpoint(request.getId()), request,
+        return httpUtils.get(config, getCollectorEndpoint(request.getId()), request,
                 HttpUtils.toRequestHeaders(),
                 new SumoEntityResponseHandler<GetCollectorRequest,
                         GetCollectorResponse>(GetCollectorResponse.class),
@@ -28,21 +35,21 @@ public class CollectorsClient {
     }
 
     public UpdateCollectorResponse update(ConnectionConfig config, UpdateCollectorRequest request) {
-        return HttpUtils.put(config, getCollectorEndpoint(request.getId()), request,
+        return httpUtils.put(config, getCollectorEndpoint(request.getId()), request,
                 new SumoEntityResponseHandler<UpdateCollectorRequest,
                         UpdateCollectorResponse>(UpdateCollectorResponse.class),
                 HttpStatus.SC_OK);
     }
 
     public DeleteCollectorResponse delete(ConnectionConfig config, DeleteCollectorRequest request) {
-        return HttpUtils.delete(config, getCollectorEndpoint(request.getId()), request,
+        return httpUtils.delete(config, getCollectorEndpoint(request.getId()), request,
                 new PassingResponseHandler<DeleteCollectorRequest,
                         DeleteCollectorResponse>(new DeleteCollectorResponse()),
                 HttpStatus.SC_OK);
     }
 
     public GetSourcesResponse getSources(ConnectionConfig config, GetSourcesRequest request) {
-        return HttpUtils.get(config, getSourcesEndpoint(request.getCollectorId()), request,
+        return httpUtils.get(config, getSourcesEndpoint(request.getCollectorId()), request,
                 HttpUtils.toRequestHeaders(),
                 new DeserializingResponseHandler<GetSourcesRequest,
                         GetSourcesResponse>(GetSourcesResponse.class),
@@ -51,7 +58,7 @@ public class CollectorsClient {
 
     public GetSourceResponse getSource(ConnectionConfig config, GetSourceRequest request) {
         String sourceEndpoint = getSourceEndpoint(request.getCollectorId(), request.getSourceId());
-        return HttpUtils.get(config, sourceEndpoint, request,
+        return httpUtils.get(config, sourceEndpoint, request,
                 HttpUtils.toRequestHeaders(),
                 new SumoEntityResponseHandler<GetSourceRequest,
                         GetSourceResponse>(GetSourceResponse.class),
@@ -59,7 +66,7 @@ public class CollectorsClient {
     }
 
     public CreateSourceResponse createSource(ConnectionConfig config, CreateSourceRequest request) {
-        return HttpUtils.post(config, getSourcesEndpoint(request.getCollectorId()), request,
+        return httpUtils.post(config, getSourcesEndpoint(request.getCollectorId()), request,
                 HttpUtils.toRequestHeaders(),
                 new SumoEntityResponseHandler<CreateSourceRequest,
                         CreateSourceResponse>(CreateSourceResponse.class),
@@ -68,7 +75,7 @@ public class CollectorsClient {
 
     public UpdateSourceResponse updateSource(ConnectionConfig config, UpdateSourceRequest request) {
         String sourceEndpoint = getSourceEndpoint(request.getCollectorId(), request.getSourceId());
-        return HttpUtils.put(config, sourceEndpoint, request,
+        return httpUtils.put(config, sourceEndpoint, request,
                 new SumoEntityResponseHandler<UpdateSourceRequest,
                         UpdateSourceResponse>(UpdateSourceResponse.class),
                 HttpStatus.SC_OK);
@@ -76,7 +83,7 @@ public class CollectorsClient {
 
     public DeleteSourceResponse deleteSource(ConnectionConfig config, DeleteSourceRequest request) {
         String sourceEndpoint = getSourceEndpoint(request.getCollectorId(), request.getSourceId());
-        return HttpUtils.delete(config, sourceEndpoint, request,
+        return httpUtils.delete(config, sourceEndpoint, request,
                 new PassingResponseHandler<DeleteSourceRequest,
                         DeleteSourceResponse>(new DeleteSourceResponse()),
                 HttpStatus.SC_OK);

--- a/src/main/java/com/sumologic/client/search/SearchClient.java
+++ b/src/main/java/com/sumologic/client/search/SearchClient.java
@@ -18,8 +18,14 @@ import java.util.List;
 
 public class SearchClient {
 
+    private HttpUtils httpUtils;
+
+    public SearchClient(HttpUtils httpUtils) {
+        this.httpUtils = httpUtils;
+    }
+
     public SearchResponse search(ConnectionConfig config, SearchRequest request) {
-        return HttpUtils.get(config, getSearchEndpoint(), request,
+        return httpUtils.get(config, getSearchEndpoint(), request,
                 HttpUtils.toRequestHeaders(), new SearchHandler(), HttpStatus.SC_OK);
     }
 

--- a/src/main/java/com/sumologic/client/searchjob/SearchJobClient.java
+++ b/src/main/java/com/sumologic/client/searchjob/SearchJobClient.java
@@ -15,12 +15,18 @@ public class SearchJobClient {
 
     // Implementation.
 
+    private HttpUtils httpUtils;
+
+    public SearchJobClient(HttpUtils httpUtils) {
+        this.httpUtils = httpUtils;
+    }
+
     public String createSearchJob(
             ConnectionConfig connection,
             CreateSearchJobRequest createSearchJobRequest) {
 
         String uri = UrlParameters.SEARCH_JOBS_SERVICE;
-        return HttpUtils.post(
+        return httpUtils.post(
                 connection,
                 uri,
                 createSearchJobRequest,
@@ -38,7 +44,7 @@ public class SearchJobClient {
 
         String uri = UrlParameters.SEARCH_JOBS_SERVICE +
                 "/" + getSearchJobStatusRequest.getId();
-        return HttpUtils.get(
+        return httpUtils.get(
                 connection,
                 uri,
                 getSearchJobStatusRequest,
@@ -56,7 +62,7 @@ public class SearchJobClient {
         String uri = UrlParameters.SEARCH_JOBS_SERVICE +
                 "/" + getMessagesForSearchJobRequest.getId() +
                 "/" + UrlParameters.SEARCH_JOBS_SERVICE_MESSAGES;
-        return HttpUtils.get(
+        return httpUtils.get(
                 connection,
                 uri,
                 getMessagesForSearchJobRequest,
@@ -74,7 +80,7 @@ public class SearchJobClient {
         String uri = UrlParameters.SEARCH_JOBS_SERVICE +
                 "/" + getRecordsForSearchJobRequest.getId() +
                 "/" + UrlParameters.SEARCH_JOBS_SERVICE_RECORDS;
-        return HttpUtils.get(
+        return httpUtils.get(
                 connection,
                 uri,
                 getRecordsForSearchJobRequest,
@@ -91,7 +97,7 @@ public class SearchJobClient {
 
         String uri = UrlParameters.SEARCH_JOBS_SERVICE +
                 "/" + cancelSearchJobRequest.getId();
-        return HttpUtils.delete(
+        return httpUtils.delete(
                 connection,
                 uri,
                 cancelSearchJobRequest,

--- a/src/main/java/com/sumologic/client/util/HttpUtils.java
+++ b/src/main/java/com/sumologic/client/util/HttpUtils.java
@@ -35,11 +35,11 @@ public class HttpUtils {
 
     private static final String JSON_CONTENT_TYPE = "application/json";
 
-    private static final CookieStore cookieStore = new BasicCookieStore();
+    private final CookieStore cookieStore = new BasicCookieStore();
 
     // Public HTTP request methods
 
-    public static <Request extends HttpGetRequest, Response> Response
+    public <Request extends HttpGetRequest, Response> Response
     get(ConnectionConfig config, String endpoint,
         Request request, Map<String, String> requestHeaders,
         ResponseHandler<Request, Response> handler, int expectedStatusCode) {
@@ -57,7 +57,7 @@ public class HttpUtils {
         }
     }
 
-    public static <Request extends HttpPostRequest, Response> Response
+    public <Request extends HttpPostRequest, Response> Response
     post(ConnectionConfig config, String endpoint,
          Request request, Map<String, String> requestHeaders,
          ResponseHandler<Request, Response> handler, int expectedStatusCode) {
@@ -87,7 +87,7 @@ public class HttpUtils {
         }
     }
 
-    public static <Request extends HttpPutRequest, Response> Response
+    public <Request extends HttpPutRequest, Response> Response
     put(ConnectionConfig config, String endpoint,
         Request request, ResponseHandler<Request, Response> handler, int expectedStatusCode) {
 
@@ -121,7 +121,7 @@ public class HttpUtils {
         }
     }
 
-    public static <Request extends HttpDeleteRequest, Response> Response
+    public <Request extends HttpDeleteRequest, Response> Response
     delete(ConnectionConfig config, String endpoint,
            Request request, ResponseHandler<Request, Response> handler, int expectedStatusCode) {
 
@@ -149,7 +149,7 @@ public class HttpUtils {
 
     // Private methods
 
-    private static HttpClient getHttpClient(ConnectionConfig config) {
+    private HttpClient getHttpClient(ConnectionConfig config) {
         DefaultHttpClient httpClient = new DefaultHttpClient();
         httpClient.setCookieStore(cookieStore);
         httpClient.getCredentialsProvider().setCredentials(config.getAuthScope(),
@@ -163,7 +163,7 @@ public class HttpUtils {
                 "/" + endpoint;
     }
 
-    private static <Request, Response> Response
+    private <Request, Response> Response
     doRequest(ConnectionConfig config, HttpUriRequest method, Map<String, String> requestHeaders,
               Request request, ResponseHandler<Request, Response> handler, int expectedStatusCode) {
 


### PR DESCRIPTION
Fix API IT failures by making HttpUtils use instance methods and not static methods.
Thus, a SumoLogicClient has an instance of HttpUtils (which maps to a cookie factory),
which is then passed on to every one of the clients.
