### PR TITLE
add the proxy support so people can talk to sumo via proxy through this proxy

### DIFF
--- a/src/main/java/com/sumologic/client/ConnectionConfig.java
+++ b/src/main/java/com/sumologic/client/ConnectionConfig.java
@@ -1,5 +1,6 @@
 package com.sumologic.client;
 
+import org.apache.http.HttpHost;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
 
@@ -9,12 +10,20 @@ public class ConnectionConfig {
     private String hostname;
     private int port;
     private Credentials credentials;
+    private HttpHost proxy;
 
     public ConnectionConfig(String protocol, String hostname, int port, Credentials credentials) {
+        this(protocol, hostname, port, credentials, null, null, 0);
+    }
+
+    public ConnectionConfig(String protocol, String hostname, int port, Credentials credentials, String proxyProtocol, String proxyHost, int proxyPort) {
         this.protocol = protocol;
         this.hostname = hostname;
         this.port = port;
         this.credentials = credentials;
+        if (proxyHost != null) {
+            proxy = new HttpHost(proxyHost, proxyPort, proxyProtocol);
+        }
     }
 
     public String getProtocol() {
@@ -28,6 +37,8 @@ public class ConnectionConfig {
     public int getPort() {
         return port;
     }
+
+    public HttpHost getProxy() { return proxy;}
 
     public Credentials getCredentials() {
         return credentials;

--- a/src/main/java/com/sumologic/client/SumoLogicClient.java
+++ b/src/main/java/com/sumologic/client/SumoLogicClient.java
@@ -37,6 +37,9 @@ public class SumoLogicClient implements SumoLogic {
     private String hostname = "api.sumologic.com";
     private int port = 443;
     private Credentials credentials;
+    private String proxyHost;
+    private int proxyPort;
+    private String proxyProtocol;
     private static JsonFactory jsonFactory = new JsonFactory();
 
     private SearchClient searchClient = new SearchClient(httpUtils);
@@ -80,8 +83,18 @@ public class SumoLogicClient implements SumoLogic {
         this.protocol = url.getProtocol();
     }
 
+    public void setProxyHost(String proxyHost) {
+        this.proxyHost = proxyHost;
+    }
+
+    public void setProxyPort(int proxyPort) {
+        this.proxyPort = proxyPort;
+    }
+
+    public void setProxyProtocol(String proxyProtocol) {this.proxyProtocol = proxyProtocol;}
+
     private ConnectionConfig getConnectionConfig() {
-        return new ConnectionConfig(protocol, hostname, port, credentials);
+        return new ConnectionConfig(protocol, hostname, port, credentials, proxyProtocol, proxyHost, proxyPort);
     }
 
     //


### PR DESCRIPTION
Howdy folks! 
Added the support for non-authenticating proxy (it would be trivial to support that, too). Replaced the deprecated DefaultHttpClient with CloseableHttpClient to make it easier to work with the proxy. Speaking of which, it seems that we create a new instance of the httpClient for every request - a bit of waste. I didn't change that part. Maybe later.
I have tested against squid and it works fine. 