### PR TITLE
Tweak the wording in the README about SearchJobClient.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Sumo Logic provides a cloud-based log management solution. It can process and analyze log files in peta-byte scale. This library provides a Java client to execute searches on the data collected by the Sumo Logic service.
 
 ## News
-  * 2017-02-21: [The Search API](https://github.com/SumoLogic/sumo-api-doc/wiki/Search-API) has been deprecated and will be removed in the next release. Please migrate to the [Search Job API](https://help.sumologic.com/APIs/02Search_Job_API/About_the_Search_Job_API).
+  * 2017-02-21: [The Search API](https://github.com/SumoLogic/sumo-api-doc/wiki/Search-API) has been deprecated and will be removed in the next release. Please migrate to the [Search Job API](https://help.sumologic.com/APIs/02Search_Job_API/About_the_Search_Job_API) by using the `SearchJobClient` class.
   * 2016-09-16: Version 2.2 released to maven central.
   * 2015-11-23: Version 2.1 released to maven central.
   * 2014-10-30: Version 2.0 released to maven central.
@@ -27,10 +27,9 @@ to your pom.xml
 
 ## Current Limitations and Known Bugs
 
-The older Search API has currently has the following limitations:
+The older Search API has serious limitations; we strongly recommend you to use the Search Job API with the `SearchJobClient` class instead.  If you continue to use the deprecated `SearchClient` class, you will have the following limitations:
   * A maximum of 100k log lines are returned at once. If you need more data you can issue subsequent queries covering a smaller time frame.
   * Queries need to complete in 60 seconds. Otherwise the session will timeout and no results are returned.
-  * As a result, we strongly recommend you to use the Search Job API with the `SearchJobClient` class.
 
 ## License
 


### PR DESCRIPTION
I found the README a little confusing when I first read it (e.g. the external link to the search job API without a corresponding mention of an interface in this library made me think at first that we weren't implementing the search job API in this library at all) - when I reread it, I realized that I had misunderstood it, but I figure it's worth a tweak in case other people have the same reaction?