### PR TITLE
SUMO-79482 Add support for streaming metrics source in java client

### DIFF
--- a/src/main/java/com/sumologic/client/collectors/model/Source.java
+++ b/src/main/java/com/sumologic/client/collectors/model/Source.java
@@ -45,6 +45,7 @@ public class Source extends SumoEntity {
     private Boolean forceTimeZone;
     private String defaultDateFormat;
     private String sourceType;
+    private String contentType;
     private Boolean alive;
     private String status;
     private List<Filter> filters = new ArrayList<Filter>();
@@ -256,6 +257,22 @@ public class Source extends SumoEntity {
      */
     public void setSourceType(String sourceType) {
         this.sourceType = sourceType;
+    }
+
+    /**
+     * Returns the content type.
+     *
+     * @return The content type.
+     */
+    public String getContentType() {
+        return contentType;
+    }
+
+    /**
+     * Sets the content type.
+     */
+    public void setContentType(String contentType) {
+        this.contentType = contentType;
     }
 
     /**

--- a/src/main/java/com/sumologic/client/collectors/model/SourceType.java
+++ b/src/main/java/com/sumologic/client/collectors/model/SourceType.java
@@ -33,7 +33,8 @@ public enum SourceType {
     SCRIPT("Script", ScriptSource.class),
     ALERT("Alert", AlertSource.class),
     AMAZON_S3("AmazonS3", AmazonS3Source.class),
-    HTTP("HTTP", HttpSource.class);
+    HTTP("HTTP", HttpSource.class),
+    STREAMING_METRICS("StreamingMetrics", StreamingMetricsSource.class);
 
     private String type;
     private Class<? extends Source> sourceClass;

--- a/src/main/java/com/sumologic/client/collectors/model/StreamingMetricsSource.java
+++ b/src/main/java/com/sumologic/client/collectors/model/StreamingMetricsSource.java
@@ -1,0 +1,58 @@
+package com.sumologic.client.collectors.model;
+
+public class StreamingMetricsSource extends Source {
+
+    private static String PROTOCOL = "protocol";
+    private static String PORT = "port";
+    private static String CONTENT_TYPE = "content_type";
+
+    public StreamingMetricsSource() { setSourceType(SourceType.STREAMING_METRICS.getType()); }
+
+    /**
+     * Returns the protocol.
+     *
+     * @return The protocol.
+     */
+    public String getProtocol() {
+        return getProperty(PROTOCOL);
+    }
+
+    /**
+     * Sets the protocol.
+     */
+    public void setProtocol(String protocol) {
+        setProperty(PROTOCOL, protocol);
+    }
+
+    /**
+     * Returns the port.
+     *
+     * @return The port.
+     */
+    public Integer getPort() {
+        return getProperty(PORT);
+    }
+
+    /**
+     * Sets the port.
+     */
+    public void setPort(Integer port) {
+        setProperty(PORT, port);
+    }
+
+    /**
+     * Returns the content type.
+     *
+     * @return The content type.
+     */
+    public String getContentType() {
+        return getProperty(CONTENT_TYPE);
+    }
+
+    /**
+     * Sets the protocol.
+     */
+    public void setContentType(String contentType) {
+        setProperty(CONTENT_TYPE, contentType);
+    }
+}

--- a/src/main/java/com/sumologic/client/collectors/model/StreamingMetricsSource.java
+++ b/src/main/java/com/sumologic/client/collectors/model/StreamingMetricsSource.java
@@ -4,7 +4,6 @@ public class StreamingMetricsSource extends Source {
 
     private static String PROTOCOL = "protocol";
     private static String PORT = "port";
-    private static String CONTENT_TYPE = "content_type";
 
     public StreamingMetricsSource() { setSourceType(SourceType.STREAMING_METRICS.getType()); }
 
@@ -38,21 +37,5 @@ public class StreamingMetricsSource extends Source {
      */
     public void setPort(Integer port) {
         setProperty(PORT, port);
-    }
-
-    /**
-     * Returns the content type.
-     *
-     * @return The content type.
-     */
-    public String getContentType() {
-        return getProperty(CONTENT_TYPE);
-    }
-
-    /**
-     * Sets the content type.
-     */
-    public void setContentType(String contentType) {
-        setProperty(CONTENT_TYPE, contentType);
     }
 }

--- a/src/main/java/com/sumologic/client/collectors/model/StreamingMetricsSource.java
+++ b/src/main/java/com/sumologic/client/collectors/model/StreamingMetricsSource.java
@@ -50,7 +50,7 @@ public class StreamingMetricsSource extends Source {
     }
 
     /**
-     * Sets the protocol.
+     * Sets the content type.
      */
     public void setContentType(String contentType) {
         setProperty(CONTENT_TYPE, contentType);


### PR DESCRIPTION
According to SUMO-77602, we have created a source called the streaming metrics source for the installed collector. 
A logical step is to add the support for creating and updating the streaming metrics source from the sumo-java-client. In that spirit, this PR adds the required support in the java client.