### PR TITLE
SUMO-79482 Adding license header to StreamingMetrics source and updating pom version

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The Java client library is available on Maven central (http://search.maven.org/)
 <dependency>
   <groupId>com.sumologic.api.client</groupId>
   <artifactId>sumo-java-client</artifactId> 
-  <version>2.4</version>
+  <version>2.5</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.sumologic.api.client</groupId>
   <artifactId>sumo-java-client</artifactId>
-  <version>2.4-SNAPSHOT</version>
+  <version>2.6-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Sumo Logic Java Client Library</name>
   <description>The Java client for the Sumo Logic log management service</description>

--- a/src/main/java/com/sumologic/client/collectors/model/StreamingMetricsSource.java
+++ b/src/main/java/com/sumologic/client/collectors/model/StreamingMetricsSource.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package com.sumologic.client.collectors.model;
 
 public class StreamingMetricsSource extends Source {


### PR DESCRIPTION
Adding license header to `streamingMetricsSource.java` to pass the license check. Also updating the pom version to point to the next version snapshot.