### PR TITLE
`doubleField` now uses field names, Fixes #45

### DIFF
--- a/src/main/java/com/sumologic/client/searchjob/model/SearchJobRecord.java
+++ b/src/main/java/com/sumologic/client/searchjob/model/SearchJobRecord.java
@@ -82,7 +82,7 @@ public class SearchJobRecord {
      * @return The value for the specified field as a double.
      */
     public double doubleField(String fieldName) {
-        return Double.parseDouble(fieldName);
+        return Double.parseDouble(stringField(fieldName));
     }
 
     /**


### PR DESCRIPTION
Fixes #45.
Previously: `doubleField()` call on `SearchJobRecord` was bound to fail always.
Now: handled properly (as other methods)