### PR TITLE
Add by receipt time parameter to search job

### DIFF
--- a/src/main/java/com/sumologic/client/SumoLogic.java
+++ b/src/main/java/com/sumologic/client/SumoLogic.java
@@ -47,6 +47,20 @@ public interface SumoLogic {
             String query, String fromExpression, String toExpression, String timeZone);
 
     /**
+     * Starts a search job and receive a job ID for subsequent
+     * polling of the search status.
+     *
+     * @param query          The query.
+     * @param fromExpression The from expression.
+     * @param toExpression   The toExpression.
+     * @param timeZone       The time zone.
+     * @param byReceiptTime  Search by receipt time instead of message time
+     * @return The search job ID.
+     */
+    String createSearchJob(
+            String query, String fromExpression, String toExpression, String timeZone, String byReceiptTime);
+
+    /**
      * Returns the current status of a search job.
      *
      * @param searchJobId The search job ID.

--- a/src/main/java/com/sumologic/client/SumoLogic.java
+++ b/src/main/java/com/sumologic/client/SumoLogic.java
@@ -41,11 +41,10 @@ public interface SumoLogic {
      * @param fromExpression The from expression.
      * @param toExpression   The toExpression.
      * @param timeZone       The time zone.
-     * @param byReceiptTime  Search by receipt time instead of message time.
      * @return The search job ID.
      */
     String createSearchJob(
-            String query, String fromExpression, String toExpression, String timeZone, String byReceiptTime);
+            String query, String fromExpression, String toExpression, String timeZone);
 
     /**
      * Returns the current status of a search job.

--- a/src/main/java/com/sumologic/client/SumoLogic.java
+++ b/src/main/java/com/sumologic/client/SumoLogic.java
@@ -41,10 +41,11 @@ public interface SumoLogic {
      * @param fromExpression The from expression.
      * @param toExpression   The toExpression.
      * @param timeZone       The time zone.
+     * @param byReceiptTime  Search by receipt time instead of message time.
      * @return The search job ID.
      */
     String createSearchJob(
-            String query, String fromExpression, String toExpression, String timeZone);
+            String query, String fromExpression, String toExpression, String timeZone, String byReceiptTime);
 
     /**
      * Returns the current status of a search job.

--- a/src/main/java/com/sumologic/client/SumoLogicClient.java
+++ b/src/main/java/com/sumologic/client/SumoLogicClient.java
@@ -110,10 +110,26 @@ public class SumoLogicClient implements SumoLogic {
      * @param fromExpression The from expression.
      * @param toExpression   The toExpression.
      * @param timeZone       The time zone.
-     * @param byReceiptTime  Search by receipt time instead of message time
      * @return The search job ID.
      */
     @Override
+    public String createSearchJob(
+            String query, String fromExpression, String toExpression, String timeZone) {
+        return createSearchJob(query, fromExpression, toExpression, timeZone, "false");
+    }
+
+
+    /**
+     * Starts a search job and receives a job ID for subsequent
+     * polling of the search status.
+     *
+     * @param query          The query.
+     * @param fromExpression The from expression.
+     * @param toExpression   The toExpression.
+     * @param timeZone       The time zone.
+     * @param byReceiptTime  Search by receipt time instead of message time
+     * @return The search job ID.
+     */
     public String createSearchJob(
             String query, String fromExpression, String toExpression, String timeZone, String byReceiptTime) {
         CreateSearchJobRequest createSearchJobRequest =

--- a/src/main/java/com/sumologic/client/SumoLogicClient.java
+++ b/src/main/java/com/sumologic/client/SumoLogicClient.java
@@ -110,13 +110,14 @@ public class SumoLogicClient implements SumoLogic {
      * @param fromExpression The from expression.
      * @param toExpression   The toExpression.
      * @param timeZone       The time zone.
+     * @param byReceiptTime  Search by receipt time instead of message time
      * @return The search job ID.
      */
     @Override
     public String createSearchJob(
-            String query, String fromExpression, String toExpression, String timeZone) {
+            String query, String fromExpression, String toExpression, String timeZone, String byReceiptTime) {
         CreateSearchJobRequest createSearchJobRequest =
-                new CreateSearchJobRequest(query, fromExpression, toExpression, timeZone);
+                new CreateSearchJobRequest(query, fromExpression, toExpression, timeZone, byReceiptTime);
         return searchJobClient.createSearchJob(
                 getConnectionConfig(), createSearchJobRequest);
     }

--- a/src/main/java/com/sumologic/client/SumoLogicClient.java
+++ b/src/main/java/com/sumologic/client/SumoLogicClient.java
@@ -130,6 +130,7 @@ public class SumoLogicClient implements SumoLogic {
      * @param byReceiptTime  Search by receipt time instead of message time
      * @return The search job ID.
      */
+    @Override
     public String createSearchJob(
             String query, String fromExpression, String toExpression, String timeZone, String byReceiptTime) {
         CreateSearchJobRequest createSearchJobRequest =

--- a/src/main/java/com/sumologic/client/searchjob/SearchJobExample.java
+++ b/src/main/java/com/sumologic/client/searchjob/SearchJobExample.java
@@ -82,7 +82,8 @@ public class SearchJobExample {
                 "* | count _sourceHost",  // This query will return all messages
                 "2013-03-10T13:10:00",    // between this start time and
                 "2013-03-10T13:11:00",    // this end time, specified in ISO 8601 format
-                "america/los_angeles");   // and assuming we are in California.
+                "america/los_angeles",    // and assuming we are in California.
+                "false");                 // use message time by default
 
         // Note - above we are specifying the time
         // range using the ISO 8601 timestamp format.

--- a/src/main/java/com/sumologic/client/searchjob/SearchJobResultDumper.java
+++ b/src/main/java/com/sumologic/client/searchjob/SearchJobResultDumper.java
@@ -77,6 +77,8 @@ public class SearchJobResultDumper {
         // The timezone to interpret from and to in if given as ISO8601
         String timezone = null;
 
+        String byReceiptTime = null;
+
         // In chunk mode, the number of hours to execute the search query in.
         long chunkIncrementMillis = -1;
 
@@ -177,6 +179,10 @@ public class SearchJobResultDumper {
             if (commandLine.hasOption("minutes")) {
                 chunkIncrementMillis =
                         1000L * 60 * Long.parseLong(commandLine.getOptionValue("minutes"));
+            }
+
+            if (commandLine.hasOption("byReceiptTime")) {
+                byReceiptTime = commandLine.getOptionValue("byReceiptTime");
             }
 
             searchQuery = commandLine.getOptionValue("query");
@@ -280,7 +286,8 @@ public class SearchJobResultDumper {
                         "" + chunkEndMillis,
                         timezone,
                         retry,
-                        lastEndFile);
+                        lastEndFile,
+                        byReceiptTime);
                 if (failure) {
                     break;
                 }
@@ -366,6 +373,12 @@ public class SearchJobResultDumper {
                         .withDescription("The timezone to interpret from and to in")
                         .hasArg()
                         .create("tz"));
+        options.addOption(
+                OptionBuilder.withLongOpt("byReceiptTime")
+                        .withArgName("byReceiptTime")
+                        .withDescription("Search by receipt time instead of message time")
+                        .hasArg()
+                        .create("rt"));
         options.addOption(
                 OptionBuilder.withLongOpt("hours")
                         .withArgName("hours")
@@ -476,7 +489,8 @@ public class SearchJobResultDumper {
                                                      String endTimestamp,
                                                      String timeZone,
                                                      int retry,
-                                                     String lastEndFile) {
+                                                     String lastEndFile,
+                                                     String byReceiptTime) {
 
         int triesLeft = retry;
         int attempt = 1;
@@ -499,7 +513,8 @@ public class SearchJobResultDumper {
                     endTimestamp,
                     timeZone,
                     attempt,
-                    lastEndFile);
+                    lastEndFile,
+                    byReceiptTime);
 
             if (failure) {
                 System.err.println(String.format(
@@ -525,14 +540,16 @@ public class SearchJobResultDumper {
                                          String endTimestamp,
                                          String timeZone,
                                          int attempt,
-                                         String lastEndFile) {
+                                         String lastEndFile,
+                                         String byReceiptTime) {
 
         // Create the search job.
         String searchJobId = sumoClient.createSearchJob(
                 searchQuery,
                 startTimestamp,
                 endTimestamp,
-                timeZone);
+                timeZone,
+                byReceiptTime);
 
         System.err.printf("[%s] %s - Search job ID: '%s', attempt: '%d'\n",
                 new Date(), prefix, searchJobId, attempt);

--- a/src/main/java/com/sumologic/client/searchjob/model/CreateSearchJobRequest.java
+++ b/src/main/java/com/sumologic/client/searchjob/model/CreateSearchJobRequest.java
@@ -26,6 +26,7 @@ public final class CreateSearchJobRequest implements HttpPostRequest {
     private String from;
     private String to;
     private String timeZone;
+    private String byReceiptTime;
 
     /**
      * Creates a search job request.
@@ -38,11 +39,13 @@ public final class CreateSearchJobRequest implements HttpPostRequest {
     public CreateSearchJobRequest(String query,
                                   String from,
                                   String to,
-                                  String timeZone) {
+                                  String timeZone,
+                                  String byReceiptTime) {
         this.query = query;
         this.from = from;
         this.to = to;
         this.timeZone = timeZone;
+        this.byReceiptTime = byReceiptTime;
     }
 
     /**
@@ -148,6 +151,33 @@ public final class CreateSearchJobRequest implements HttpPostRequest {
      */
     public CreateSearchJobRequest withTimeZone(String timeZone) {
         setTimeZone(timeZone);
+        return this;
+    }
+
+    /**
+     * Returns the by receipt time flag.
+     *
+     * @return The by receipt time flag.
+     */
+    public String getByReceiptTime() {
+        return byReceiptTime;
+    }
+
+    /**
+     * Sets the by receipt time flag.
+     */
+    public void setByReceiptTime(String byReceiptTime) {
+        this.byReceiptTime = byReceiptTime;
+    }
+
+    /**
+     * Sets the by receipt time flag.
+     *
+     * @return This object.
+     */
+
+    public CreateSearchJobRequest withByReceiptTime(String byReceiptTime) {
+        setByReceiptTime(byReceiptTime);
         return this;
     }
 }


### PR DESCRIPTION
The sumo api already supports the byReceiptTime, but the java client doesn't accept this parameter yet. This parameter is added to the search_job endpoint (defaults to message time).