### PR TITLE
Upgrading Jackson to latest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,18 +127,18 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <version>4.5.1</version>
+      <version>4.5.9</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.9.8</version>
+      <version>2.9.9</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.8</version>
+      <version>2.9.9.1</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -149,7 +149,7 @@
     <dependency>
       <groupId>commons-cli</groupId>
       <artifactId>commons-cli</artifactId>
-      <version>1.2</version>
+      <version>1.4</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Upgrading the Jackson library, and others by the way.

Testing performed:
- `mvn compile` works
- `mvn compile exec:java -Dexec.mainClass="com.sumologic.client.searchjob.SearchJobExample"` starts the execution