### PR TITLE
Updating license header

### DIFF
--- a/src/main/java/com/sumologic/client/ConnectionConfig.java
+++ b/src/main/java/com/sumologic/client/ConnectionConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/Credentials.java
+++ b/src/main/java/com/sumologic/client/Credentials.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/Defaults.java
+++ b/src/main/java/com/sumologic/client/Defaults.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/SumoClientException.java
+++ b/src/main/java/com/sumologic/client/SumoClientException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/SumoException.java
+++ b/src/main/java/com/sumologic/client/SumoException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/SumoLogic.java
+++ b/src/main/java/com/sumologic/client/SumoLogic.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/SumoLogicClient.java
+++ b/src/main/java/com/sumologic/client/SumoLogicClient.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/SumoSearchErrors.java
+++ b/src/main/java/com/sumologic/client/SumoSearchErrors.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/SumoServerError.java
+++ b/src/main/java/com/sumologic/client/SumoServerError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/SumoServerErrors.java
+++ b/src/main/java/com/sumologic/client/SumoServerErrors.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/SumoServerException.java
+++ b/src/main/java/com/sumologic/client/SumoServerException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/UrlParameters.java
+++ b/src/main/java/com/sumologic/client/UrlParameters.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/collectors/CollectorAndBladeIdDumper.java
+++ b/src/main/java/com/sumologic/client/collectors/CollectorAndBladeIdDumper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/collectors/CollectorsClient.java
+++ b/src/main/java/com/sumologic/client/collectors/CollectorsClient.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/collectors/SumoCollectorErrors.java
+++ b/src/main/java/com/sumologic/client/collectors/SumoCollectorErrors.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/collectors/model/AlertSource.java
+++ b/src/main/java/com/sumologic/client/collectors/model/AlertSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/collectors/model/AmazonS3Source.java
+++ b/src/main/java/com/sumologic/client/collectors/model/AmazonS3Source.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/collectors/model/BaseScriptSource.java
+++ b/src/main/java/com/sumologic/client/collectors/model/BaseScriptSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/collectors/model/Collector.java
+++ b/src/main/java/com/sumologic/client/collectors/model/Collector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/collectors/model/CreateCollectorRequest.java
+++ b/src/main/java/com/sumologic/client/collectors/model/CreateCollectorRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/collectors/model/CreateCollectorResponse.java
+++ b/src/main/java/com/sumologic/client/collectors/model/CreateCollectorResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/collectors/model/CreateSourceRequest.java
+++ b/src/main/java/com/sumologic/client/collectors/model/CreateSourceRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/collectors/model/CreateSourceResponse.java
+++ b/src/main/java/com/sumologic/client/collectors/model/CreateSourceResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/collectors/model/DeleteCollectorRequest.java
+++ b/src/main/java/com/sumologic/client/collectors/model/DeleteCollectorRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/collectors/model/DeleteCollectorResponse.java
+++ b/src/main/java/com/sumologic/client/collectors/model/DeleteCollectorResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/collectors/model/DeleteSourceRequest.java
+++ b/src/main/java/com/sumologic/client/collectors/model/DeleteSourceRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/collectors/model/DeleteSourceResponse.java
+++ b/src/main/java/com/sumologic/client/collectors/model/DeleteSourceResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/collectors/model/Filter.java
+++ b/src/main/java/com/sumologic/client/collectors/model/Filter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/collectors/model/GetCollectorRequest.java
+++ b/src/main/java/com/sumologic/client/collectors/model/GetCollectorRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/collectors/model/GetCollectorResponse.java
+++ b/src/main/java/com/sumologic/client/collectors/model/GetCollectorResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/collectors/model/GetCollectorsRequest.java
+++ b/src/main/java/com/sumologic/client/collectors/model/GetCollectorsRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/collectors/model/GetCollectorsResponse.java
+++ b/src/main/java/com/sumologic/client/collectors/model/GetCollectorsResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/collectors/model/GetSourceRequest.java
+++ b/src/main/java/com/sumologic/client/collectors/model/GetSourceRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/collectors/model/GetSourceResponse.java
+++ b/src/main/java/com/sumologic/client/collectors/model/GetSourceResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/collectors/model/GetSourcesRequest.java
+++ b/src/main/java/com/sumologic/client/collectors/model/GetSourcesRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/collectors/model/GetSourcesResponse.java
+++ b/src/main/java/com/sumologic/client/collectors/model/GetSourcesResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/collectors/model/HostedCollector.java
+++ b/src/main/java/com/sumologic/client/collectors/model/HostedCollector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/collectors/model/HttpSource.java
+++ b/src/main/java/com/sumologic/client/collectors/model/HttpSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/collectors/model/InstallableCollector.java
+++ b/src/main/java/com/sumologic/client/collectors/model/InstallableCollector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/collectors/model/LocalFileSource.java
+++ b/src/main/java/com/sumologic/client/collectors/model/LocalFileSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/collectors/model/RemoteFileSource.java
+++ b/src/main/java/com/sumologic/client/collectors/model/RemoteFileSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/collectors/model/RemoteWindowsEventLogSource.java
+++ b/src/main/java/com/sumologic/client/collectors/model/RemoteWindowsEventLogSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/collectors/model/ScriptSource.java
+++ b/src/main/java/com/sumologic/client/collectors/model/ScriptSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/collectors/model/Source.java
+++ b/src/main/java/com/sumologic/client/collectors/model/Source.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/collectors/model/SourceType.java
+++ b/src/main/java/com/sumologic/client/collectors/model/SourceType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/collectors/model/StreamingMetricsSource.java
+++ b/src/main/java/com/sumologic/client/collectors/model/StreamingMetricsSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/collectors/model/SyslogSource.java
+++ b/src/main/java/com/sumologic/client/collectors/model/SyslogSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/collectors/model/UpdateCollectorRequest.java
+++ b/src/main/java/com/sumologic/client/collectors/model/UpdateCollectorRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/collectors/model/UpdateCollectorResponse.java
+++ b/src/main/java/com/sumologic/client/collectors/model/UpdateCollectorResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/collectors/model/UpdateSourceRequest.java
+++ b/src/main/java/com/sumologic/client/collectors/model/UpdateSourceRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/collectors/model/UpdateSourceResponse.java
+++ b/src/main/java/com/sumologic/client/collectors/model/UpdateSourceResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/collectors/model/WindowsEventLogSource.java
+++ b/src/main/java/com/sumologic/client/collectors/model/WindowsEventLogSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/dashboard/DashboardClient.java
+++ b/src/main/java/com/sumologic/client/dashboard/DashboardClient.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/dashboard/DashboardExample.java
+++ b/src/main/java/com/sumologic/client/dashboard/DashboardExample.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/dashboard/model/Dashboard.java
+++ b/src/main/java/com/sumologic/client/dashboard/model/Dashboard.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/dashboard/model/DashboardMonitor.java
+++ b/src/main/java/com/sumologic/client/dashboard/model/DashboardMonitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/dashboard/model/DashboardMonitorData.java
+++ b/src/main/java/com/sumologic/client/dashboard/model/DashboardMonitorData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/dashboard/model/GetDashboardDataRequest.java
+++ b/src/main/java/com/sumologic/client/dashboard/model/GetDashboardDataRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/dashboard/model/GetDashboardDataResponse.java
+++ b/src/main/java/com/sumologic/client/dashboard/model/GetDashboardDataResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/dashboard/model/GetDashboardRequest.java
+++ b/src/main/java/com/sumologic/client/dashboard/model/GetDashboardRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/dashboard/model/GetDashboardResponse.java
+++ b/src/main/java/com/sumologic/client/dashboard/model/GetDashboardResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/dashboard/model/GetDashboardsRequest.java
+++ b/src/main/java/com/sumologic/client/dashboard/model/GetDashboardsRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/dashboard/model/GetDashboardsResponse.java
+++ b/src/main/java/com/sumologic/client/dashboard/model/GetDashboardsResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/dashboard/model/ResolvedTimeRange.java
+++ b/src/main/java/com/sumologic/client/dashboard/model/ResolvedTimeRange.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/model/HttpDeleteRequest.java
+++ b/src/main/java/com/sumologic/client/model/HttpDeleteRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/model/HttpGetRequest.java
+++ b/src/main/java/com/sumologic/client/model/HttpGetRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/model/HttpPostRequest.java
+++ b/src/main/java/com/sumologic/client/model/HttpPostRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/model/HttpPutRequest.java
+++ b/src/main/java/com/sumologic/client/model/HttpPutRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/model/LogMessage.java
+++ b/src/main/java/com/sumologic/client/model/LogMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/model/SumoEntity.java
+++ b/src/main/java/com/sumologic/client/model/SumoEntity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/model/SumoEntityResponse.java
+++ b/src/main/java/com/sumologic/client/model/SumoEntityResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/searchjob/SearchJobClient.java
+++ b/src/main/java/com/sumologic/client/searchjob/SearchJobClient.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/searchjob/SearchJobExample.java
+++ b/src/main/java/com/sumologic/client/searchjob/SearchJobExample.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/searchjob/SearchJobResultDumper.java
+++ b/src/main/java/com/sumologic/client/searchjob/SearchJobResultDumper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/searchjob/model/CancelSearchJobRequest.java
+++ b/src/main/java/com/sumologic/client/searchjob/model/CancelSearchJobRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/searchjob/model/CancelSearchJobResponse.java
+++ b/src/main/java/com/sumologic/client/searchjob/model/CancelSearchJobResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/searchjob/model/CreateSearchJobRequest.java
+++ b/src/main/java/com/sumologic/client/searchjob/model/CreateSearchJobRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/searchjob/model/CreateSearchJobResponse.java
+++ b/src/main/java/com/sumologic/client/searchjob/model/CreateSearchJobResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/searchjob/model/GetMessagesForSearchJobRequest.java
+++ b/src/main/java/com/sumologic/client/searchjob/model/GetMessagesForSearchJobRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/searchjob/model/GetMessagesForSearchJobResponse.java
+++ b/src/main/java/com/sumologic/client/searchjob/model/GetMessagesForSearchJobResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/searchjob/model/GetRecordsForSearchJobRequest.java
+++ b/src/main/java/com/sumologic/client/searchjob/model/GetRecordsForSearchJobRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/searchjob/model/GetRecordsForSearchJobResponse.java
+++ b/src/main/java/com/sumologic/client/searchjob/model/GetRecordsForSearchJobResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/searchjob/model/GetSearchJobStatusRequest.java
+++ b/src/main/java/com/sumologic/client/searchjob/model/GetSearchJobStatusRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/searchjob/model/GetSearchJobStatusResponse.java
+++ b/src/main/java/com/sumologic/client/searchjob/model/GetSearchJobStatusResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/searchjob/model/SearchJobField.java
+++ b/src/main/java/com/sumologic/client/searchjob/model/SearchJobField.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/searchjob/model/SearchJobHistogramBucket.java
+++ b/src/main/java/com/sumologic/client/searchjob/model/SearchJobHistogramBucket.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/searchjob/model/SearchJobMessage.java
+++ b/src/main/java/com/sumologic/client/searchjob/model/SearchJobMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/searchjob/model/SearchJobRecord.java
+++ b/src/main/java/com/sumologic/client/searchjob/model/SearchJobRecord.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/util/DeserializingResponseHandler.java
+++ b/src/main/java/com/sumologic/client/util/DeserializingResponseHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/util/HttpUtils.java
+++ b/src/main/java/com/sumologic/client/util/HttpUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/util/JacksonUtils.java
+++ b/src/main/java/com/sumologic/client/util/JacksonUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/util/PassingResponseHandler.java
+++ b/src/main/java/com/sumologic/client/util/PassingResponseHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/util/ResponseHandler.java
+++ b/src/main/java/com/sumologic/client/util/ResponseHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/util/SourceDeserializer.java
+++ b/src/main/java/com/sumologic/client/util/SourceDeserializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/src/main/java/com/sumologic/client/util/SumoEntityResponseHandler.java
+++ b/src/main/java/com/sumologic/client/util/SumoEntityResponseHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information


### PR DESCRIPTION
After #69, the `mvn license:check` fails with:
```
Some files do not have the expected license header
```

Fixing it with:
```
mvn license:format
```