### PR TITLE
Changing from net.sf.opencsv to com.opencsv

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,9 +141,9 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>net.sf.opencsv</groupId>
+      <groupId>com.opencsv</groupId>
       <artifactId>opencsv</artifactId>
-      <version>2.4</version>
+      <version>5.5.2</version>
     </dependency>
     <dependency>
       <groupId>commons-cli</groupId>

--- a/src/main/java/com/sumologic/client/searchjob/SearchJobResultDumper.java
+++ b/src/main/java/com/sumologic/client/searchjob/SearchJobResultDumper.java
@@ -18,8 +18,8 @@
  */
 package com.sumologic.client.searchjob;
 
-import au.com.bytecode.opencsv.CSVWriter;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.opencsv.CSVWriter;
 import com.sumologic.client.Credentials;
 import com.sumologic.client.SumoLogicClient;
 import com.sumologic.client.model.LogMessage;
@@ -32,10 +32,8 @@ import org.apache.commons.cli.*;
 import java.io.*;
 import java.net.URL;
 import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
-import java.time.temporal.ChronoField;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 


### PR DESCRIPTION
Changing from the really old `net.sf.opencsv` dependency to the new counterpart: `com.opencsv`.

Also the old one is problematic, because in some Maven repositories it's the `2.3` as the latest version which is available. While in some it's `2.4` which this project depended on. `com.opencsv` doesn't seem to have this problem.
