### PR TITLE
Upgrade gradle-build-action

### DIFF
--- a/.github/workflows/gradleTests.yml
+++ b/.github/workflows/gradleTests.yml
@@ -22,7 +22,7 @@ jobs:
         java-version: '11'
         distribution: 'temurin'
     - name: Build with Gradle
-      uses: gradle/gradle-build-action@0d13054264b0bb894ded474f08ebb30921341cee
+      uses: gradle/gradle-build-action@29c0906b64b8fc82467890bfb7a0a7ef34bda89e
       env:
         SUMO_ACCESS_ID: ${{ secrets.SUMO_ACCESS_ID }}
         SUMO_ACCESS_KEY: ${{ secrets.SUMO_ACCESS_KEY }}


### PR DESCRIPTION
**What**:
- Upgrading gradle-build-action

**Why**:
I don't need it for anything, but Dependabot has flagged that for some vulnerability, likely not affecting us.