### PR TITLE
Switching to 2024 for time range

### DIFF
--- a/src/test/scala/com/sumologic/client/searchjob/SearchJobClientTest.scala
+++ b/src/test/scala/com/sumologic/client/searchjob/SearchJobClientTest.scala
@@ -22,7 +22,7 @@ class SearchJobClientTest extends AnyWordSpecLike with Matchers with Eventually 
       // given
       val sut = SearchJobClientTest.createClient
       val queryText = "_sourceName=dummy"
-      val timeRange = Seq("2023-09-29T15:59:00", "2023-09-29T16:00:00")
+      val timeRange = Seq("2024-09-29T15:59:00", "2024-09-29T16:00:00")
 
       // when
       val searchJobId = sut.createSearchJob(


### PR DESCRIPTION
**What**:
Switching the tests to use 2024 as the search time range.

**Why**:
The immediate fix for failing tests. Not ideal. But should unblock us for this moment.